### PR TITLE
Make Uniswap a frame

### DIFF
--- a/apps/web/public/.well-known/farcaster.json
+++ b/apps/web/public/.well-known/farcaster.json
@@ -1,0 +1,15 @@
+{
+    "accountAssociation": {
+      "header": "eyJmaWQiOjM2MjEsInR5cGUiOiJjdXN0b2R5Iiwia2V5IjoiMHgyY2Q4NWEwOTMyNjFmNTkyNzA4MDRBNkVBNjk3Q2VBNENlQkVjYWZFIn0",
+      "payload": "eyJkb21haW4iOiJ1bmlmcmFtZS5vcmcifQ",
+      "signature": "MHgxZTZlZTkyNmRiZjU5ZDljZjM4MGI1YTU0ZTI2YzUxYjEyN2MyZjM2NTM3ZDJhYWI5ZGZjOTBiMDVlMjRjY2U4MzYxZDk5YmRhOGZmYWU0NjliZTY0ZWNlZTVhZTA5MjYzNWM5NjVlYzFmZmRjNDEwOGZiNjJlNmRmYmRiM2VkNDFi"
+    },
+    "frame": {
+      "name": "Uniframe",
+      "version": "0.0.1",
+      "iconUrl": "https://uniframe.org/favicon.png",
+      "homeUrl": "https://uniframe.org/#/swap",
+      "splashImageUrl": "https://uniframe.org/favicon.png",
+      "splashBackgroundColor": "#131313"
+    }
+  }

--- a/apps/web/public/index.html
+++ b/apps/web/public/index.html
@@ -16,6 +16,20 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
     <meta name="theme-color" content="#fff" />
     <meta name="format-detection" content="telephone=no">
+    <meta name="fc:frame" content='{
+      "version": "next",
+      "imageUrl": "https://uniframe.org/images/1200x630_Rich_Link_Preview_Image.png",
+      "button":{
+        "title": "Swap",
+        "action": {
+          "type": "launch_frame",
+          "name": "Uniframe",
+          "url": "https://uniframe.org/swap",
+          "splashImageUrl": "https://uniframe.org/favicon.png",
+          "splashBackgroundColor": "#131313"
+        }
+      }
+    }' data-rh="true">
 
     <!-- Skip the CSP in specified test environments -->
     <% if (!process.env.REACT_APP_SKIP_CSP) { %>

--- a/apps/web/src/components/Web3Provider/wagmiConfig.ts
+++ b/apps/web/src/components/Web3Provider/wagmiConfig.ts
@@ -1,3 +1,4 @@
+import { farcasterFrame } from '@farcaster/frame-wagmi-connector'
 import { QueryClient } from '@tanstack/react-query'
 import { injectedWithFallback } from 'components/Web3Provider/injectedWithFallback'
 import { WC_PARAMS } from 'components/Web3Provider/walletConnect'
@@ -19,6 +20,7 @@ declare module 'wagmi' {
 export const wagmiConfig = createConfig({
   chains: [getChainInfo(UniverseChainId.Mainnet), ...ALL_CHAIN_IDS.map(getChainInfo)],
   connectors: [
+    farcasterFrame(),
     injectedWithFallback(),
     walletConnect(WC_PARAMS),
     coinbaseWallet({


### PR DESCRIPTION
![GeDePj5boAE5evS](https://github.com/user-attachments/assets/7b6b5664-f3ef-49a3-99ce-319b294ea5bb)

[Farcaster Frames](https://docs.farcaster.xyz/developers/frames/v2/) are now web apps. That means if you have an existing web app that connects to a wallet, you can turn it into a frame that will:
- Display an interactive embed in the feed
- Launch your app with the user's mobile wallet already connected
- Enable users to save your app to their Farcaster client
- Surface your app in search and explore listings
- Allow you to send in-app notifications

Let's make Uniswap a frame.

## 1. Install Frame SDK and Wagmi connector packages

```
yarn add @farcaster/frame-sdk @farcaster/frame-wagmi-connector
```

## 2. Load SDK and call `ready()`

Load the Frame SDK and call `ready()` when your app loads. 

[`apps/web/src/index.tsx`](https://github.com/horsefacts/interface/pull/2/files#diff-ea2f0f9f32182f03cf005fe9764ee7fcbdb703b12adfaebaa2cc0fd9801f07ab): 

```tsx
import FrameSDK from '@farcaster/frame-sdk'
import farcasterFrame from '@farcaster/frame-wagmi-connector'
import { wagmiConfig } from 'components/Web3Provider/wagmiConfig'
import { connect } from 'wagmi/actions'

function FarcasterFrameProvider({ children }: PropsWithChildren) {
  useEffect(() => {
    const init = async () => {
      const context = await FrameSDK.context

      // Autoconnect if running in a frame.
      if (context?.client.clientFid) {
        connect(wagmiConfig, { connector: farcasterFrame() })
      }

      // Hide splash screen after UI renders.
      setTimeout(() => {
        FrameSDK.actions.ready()
      }, 500)
    }
    init()
  }, [])

  return <>{children}</>
}
```
Add to your provider stack:
```tsx
<FarcasterFrameProvider>
  <App />
</FarcasterFrameProvider>
```

## 3. Set up Wagmi connector

Add the `farcasterFrame` connector to your Wagmi config.

[`apps/web/src/components/Web3Provider/wagmiConfig.ts`](https://github.com/horsefacts/interface/pull/2/files#diff-31e192f63c44ae0597ef2f21afeee23597b5e5f61a276d4d54c30404e1fc1b0e)

```tsx
import { farcasterFrame } from '@farcaster/frame-wagmi-connector'

export const wagmiConfig = createConfig({
  chains: [getChainInfo(UniverseChainId.Mainnet), ...ALL_CHAIN_IDS.map(getChainInfo)],
  connectors: [
    farcasterFrame(),
    injectedWithFallback(),
    walletConnect(WC_PARAMS),
    coinbaseWallet({
      appName: 'Uniswap',
      // CB SDK doesn't pass the parent origin context to their passkey site
      // Flagged to CB team and can remove UNISWAP_WEB_URL once fixed
      appLogoUrl: `${UNISWAP_WEB_URL}${UNISWAP_LOGO}`,
      reloadOnDisconnect: false,
      enableMobileWalletLink: true,
    }),
    safe(),
  ],
  client({ chain }) {
    return createClient({
      chain,
      batch: { multicall: true },
      pollingInterval: 12_000,
      transport: http(chain.rpcUrls.interface.http[0]),
    })
  },
})
```

## 4. Add frame `<meta>` tags

Add a frame `<meta>` tag to any page URL you want to frame-ify. This one adds an embed to the homepage that launches into the "swap" page.

[`apps/web/public/index.html`](https://github.com/horsefacts/interface/pull/2/files#diff-c761322f82e214d2213bf36c17c39a684fb452773f7fa73fea9fed405459a8a7)

```html
    <meta name="fc:frame" content='{
      "version": "next",
      "imageUrl": "https://uniframe.org/images/1200x630_Rich_Link_Preview_Image.png",
      "button":{
        "title": "Swap",
        "action": {
          "type": "launch_frame",
          "name": "Uniframe",
          "url": "https://uniframe.org/swap",
          "splashImageUrl": "https://uniframe.org/favicon.png",
          "splashBackgroundColor": "#131313"
        }
      }
    }' data-rh="true">
```

## 5. OPTIONAL: Add a `farcaster.json` file

Optional but recommended: generate a `farcaster.json` manifest file from the Warpcast dev tools and serve it at `/.well-known/farcaster.json`. 

This associates your Farcaster account with the frame app, allows users to save it to their Farcaster client, and gives you access to in-app notifications.

[`apps/web/public/.well-known/farcaster.json`](https://github.com/horsefacts/interface/pull/2/files#diff-3f3a2fcdeb84ef6997c1f9ab7f5362adc5936880dddc6fa3c1123e145266f8e3)

```json
{
    "accountAssociation": {
      "header": "eyJmaWQiOjM2MjEsInR5cGUiOiJjdXN0b2R5Iiwia2V5IjoiMHgyY2Q4NWEwOTMyNjFmNTkyNzA4MDRBNkVBNjk3Q2VBNENlQkVjYWZFIn0",
      "payload": "eyJkb21haW4iOiJ1bmlmcmFtZS5vcmcifQ",
      "signature": "MHgxZTZlZTkyNmRiZjU5ZDljZjM4MGI1YTU0ZTI2YzUxYjEyN2MyZjM2NTM3ZDJhYWI5ZGZjOTBiMDVlMjRjY2U4MzYxZDk5YmRhOGZmYWU0NjliZTY0ZWNlZTVhZTA5MjYzNWM5NjVlYzFmZmRjNDEwOGZiNjJlNmRmYmRiM2VkNDFi"
    },
    "frame": {
      "name": "Uniframe",
      "version": "0.0.1",
      "iconUrl": "https://uniframe.org/favicon.png",
      "homeUrl": "https://uniframe.org/#/swap",
      "splashImageUrl": "https://uniframe.org/favicon.png",
      "splashBackgroundColor": "#131313"
    }
  }
  ```